### PR TITLE
Add initial tests

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/components/HeaderBar/index.tsx
+++ b/src/components/HeaderBar/index.tsx
@@ -43,7 +43,7 @@ function HeaderBar() {
     `}>
       Python Discord Forms
     </h1>
-   </div>
+  </div>
 }
 
 export default HeaderBar;

--- a/src/tests/components/FormListing.test.tsx
+++ b/src/tests/components/FormListing.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import FormListing from "../../components/FormListing";
+
+test('renders form listing with specified title', () => {
+    const { getByText } = render(<FormListing title="Example form listing" description="My form listing" open={true} />);
+    const formListing = getByText(/Example form listing/i);
+    expect(formListing).toBeInTheDocument();
+});
+
+test('renders form listing with specified description', () => {
+    const { getByText } = render(<FormListing title="Example form listing" description="My form listing" open={true} />);
+    const formListing = getByText(/My form listing/i);
+    expect(formListing).toBeInTheDocument();
+});
+
+test('renders form listing with background green colour for open', () => {
+    const { container } = render(<FormListing title="Example form listing" description="My form listing" open={true} />);
+    const elem = container.querySelector("div");
+    const style = window.getComputedStyle(elem);
+    expect(style.backgroundColor).toBe("rgb(67, 181, 129)");
+});
+
+test('renders form listing with background dark colour for closed', () => {
+    const { container } = render(<FormListing title="Example form listing" description="My form listing" open={false} />);
+    const elem = container.querySelector("div");
+    const style = window.getComputedStyle(elem);
+    expect(style.backgroundColor).toBe("rgb(44, 47, 51)");
+});

--- a/src/tests/components/HeaderBar.test.tsx
+++ b/src/tests/components/HeaderBar.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import HeaderBar from "../../components/HeaderBar";
+
+test('renders header bar with title', () => {
+    const { getByText } = render(<HeaderBar />);
+    const formListing = getByText(/Python Discord Forms/i);
+    expect(formListing).toBeInTheDocument();
+});

--- a/src/tests/components/OAuth2Button.test.tsx
+++ b/src/tests/components/OAuth2Button.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import OAuth2Button from "../../components/OAuth2Button";
+
+test('renders oauth2 sign in button text', () => {
+    const { getByText } = render(<OAuth2Button />);
+    const button = getByText(/Sign in with Discord/i);
+    expect(button).toBeInTheDocument();
+});
+
+test("renders fontawesome discord icon", () => {
+    const { container } = render(<OAuth2Button/>);
+    const icon = container.querySelector(`[data-icon="discord"]`)
+    expect(icon).toBeInTheDocument();
+})

--- a/src/tests/components/Tag.test.tsx
+++ b/src/tests/components/Tag.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Tag from "../../components/Tag";
+
+test('renders tag with specified text', () => {
+    const { getByText } = render(<Tag text="Test" color="#f0f0f0" />);
+    const tag = getByText(/Test/i);
+    expect(tag).toBeInTheDocument();
+});
+
+test('renders tag with specified color', () => {
+    const { getByText } = render(<Tag text="Test" color="#f0f0f0" />);
+    const tag = getByText(/Test/i);
+    const style = window.getComputedStyle(tag);
+    expect(style.backgroundColor).toBe("rgb(240, 240, 240)");
+});
+
+test('renders tag with specified font size', () => {
+    const { getByText } = render(<Tag text="Test" color="#f0f0f0" fontSize="2em" />);
+    const tag = getByText(/Test/i);
+    const style = window.getComputedStyle(tag);
+    expect(style.fontSize).toBe("2em");
+});
+
+test('defaults to 0.75em when no tag font size is passed', () => {
+    const { getByText } = render(<Tag text="Test" color="#f0f0f0" />);
+    const tag = getByText(/Test/i);
+    const style = window.getComputedStyle(tag);
+    expect(style.fontSize).toBe("0.75em");
+});


### PR DESCRIPTION
Adds a set of initial test for testing reused components:
- HeaderBar
- FormListing
- OAuth2Button
- Tag

<img width="333" alt="Screenshot 2020-09-28 at 04 05 03" src="https://user-images.githubusercontent.com/20439493/94386514-caaf8500-013f-11eb-946a-38eb3c66ef9f.png">
