### PR TITLE
Create test and lint workflow

### DIFF
--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -14,9 +14,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: EgorDm/gha-yarn-node-cache@v1
       
-      - name: action-yarn
-        uses: comchangs/action-yarn@v0.1-beta
-      
       - name: Install dependencies
         run: yarn install
       
@@ -29,9 +26,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: EgorDm/gha-yarn-node-cache@v1
-      
-      - name: action-yarn
-        uses: comchangs/action-yarn@v0.1-beta
       
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -1,0 +1,42 @@
+name: Test & Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: EgorDm/gha-yarn-node-cache@v1
+      
+      - name: action-yarn
+        uses: comchangs/action-yarn@v0.1-beta
+      
+      - name: Install dependencies
+        run: yarn install
+      
+      - name: Install dependencies
+        run: yarn build
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: EgorDm/gha-yarn-node-cache@v1
+      
+      - name: action-yarn
+        uses: comchangs/action-yarn@v0.1-beta
+      
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Install dependencies
+        run: yarn test
+      
+      


### PR DESCRIPTION
Adds a GitHub workflow to build the application and test it when a PR is opened targeting main.

This also introduces a dependency cache to prevent long running builds.