### PR TITLE
Fix responsive scaling for mobile devices

### DIFF
--- a/src/components/FormListing.tsx
+++ b/src/components/FormListing.tsx
@@ -22,7 +22,12 @@ function FormListing(props: FormListingProps) {
     margin-top: 20px;
     margin-bottom: 20px;
     border-radius: 10px;
-    transition: transform 100ms;
+    transition-property: transform, width;
+    transition-duration: 500ms;
+
+    @media (max-width: 575px) {
+      width: 80%;
+    }
 
     &:hover {
       transform: scale(1.01);

--- a/src/components/HeaderBar/index.tsx
+++ b/src/components/HeaderBar/index.tsx
@@ -45,6 +45,12 @@ function HeaderBar() {
       @media (max-width: 580px) {
         font-size: 2em;
       }
+
+      @media (max-width: 400px) {
+        font-size: 1.5em;
+        text-align: center;
+        margin-left: 0;
+      }
     `}>
       Python Discord Forms
     </h1>


### PR DESCRIPTION
Fixes some responsive scaling issues so now the site works better on:

### Tablet

<img width="662" alt="Screenshot 2020-09-28 at 21 29 02" src="https://user-images.githubusercontent.com/20439493/94482716-a2706680-01d1-11eb-9bf2-d29c05fa552b.png">

### Phone
<img width="311" alt="Screenshot 2020-09-28 at 21 29 20" src="https://user-images.githubusercontent.com/20439493/94482749-adc39200-01d1-11eb-8809-339c5b417ffd.png">
