### PR TITLE
Add OAuth2 authorization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,12 +12,14 @@ import { CSSTransition, TransitionGroup } from "react-transition-group";
 
 import LandingPage from "./pages/LandingPage";
 import FormPage from "./pages/FormPage";
+import CallbackPage from "./pages/CallbackPage";
 
 import globalStyles from "./globalStyles";
 
 const routes = [
   { path: "/", Component: LandingPage },
-  { path: "/form/:id", Component: FormPage}
+  { path: "/form/:id", Component: FormPage},
+  { path: "/callback", Component: CallbackPage }
 ]
 
 function App() {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import * as serviceWorker from './serviceWorker';
 
 import colors from "./colors";
 
-console.log("%c  Python Discord Forms  ", `font-size: 8em; font-family: "Hind", "Arial"; font-weight: 900; background-color: ${colors.blurple}; border-radius: 10px;`)
+console.log("%c  Python Discord Forms  ", `font-size: 6em; font-family: "Hind", "Arial"; font-weight: 900; background-color: ${colors.blurple}; border-radius: 10px;`)
 console.log("%cWelcome to Python Discord Forms", `font-size: 3em; font-family: "Hind", "Arial";`)
 
 console.log(`   Environment: %c ${process.env.NODE_ENV} `, `padding: 2px; border-radius: 5px; background-color: ${process.env.NODE_ENV === "production" ? colors.success : colors.error}`)

--- a/src/pages/CallbackPage.tsx
+++ b/src/pages/CallbackPage.tsx
@@ -1,0 +1,17 @@
+/** @jsx jsx */
+import { jsx } from "@emotion/core";
+import { useState } from "react";
+
+export default function CallbackPage() {
+    const [hasSent, setHasSent] = useState(false);
+    const params = new URLSearchParams(document.location.search);
+
+    const code = params.get("code");
+
+    if (!hasSent) {
+        setHasSent(true);
+        window.opener.postMessage(code);
+    }
+
+    return <p>Code is {code}</p>;
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -5,6 +5,7 @@ import HeaderBar from "../components/HeaderBar";
 import FormListing from "../components/FormListing";
 
 import { getForms } from "../api/forms";
+import OAuth2Button from "../components/OAuth2Button";
 
 function LandingPage() {
   return <div>
@@ -17,7 +18,9 @@ function LandingPage() {
         flex-direction: column;
       `}>
         <h1>Available Forms</h1>
-        
+
+        <OAuth2Button/>
+
 
         {getForms().map(form => (
           <FormListing key={form.id} form={form}/>


### PR DESCRIPTION
This PR adds a browser OAuth2 flow which opens the authorize window in a new tab and then closes it once the authorization has completed.

It will fetch the correct redirect URI based on the page the user is currently looking at.

<img width="612" alt="Screenshot 2020-10-06 at 14 40 29" src="https://user-images.githubusercontent.com/20439493/95209119-e3740680-07e1-11eb-8a6f-e341da656f2e.png">

Once the authorization has completed the pop-out tab will post a message back to the opener with the OAuth2 code which will in future be forwarded onto the backend for authorization.