### PR TITLE
Check for child window closure

### DIFF
--- a/src/components/OAuth2Button.tsx
+++ b/src/components/OAuth2Button.tsx
@@ -58,7 +58,7 @@ function doLogin(disableFunction: (newState: boolean) => void) {
   }, 500)
 
   window.onmessage = (code: MessageEvent) => {
-    if (code.data.hello) {
+    if (code.data.source) {
       // React DevTools has a habit of sending messages, ignore them.
       return;
     }

--- a/src/components/OAuth2Button.tsx
+++ b/src/components/OAuth2Button.tsx
@@ -50,6 +50,13 @@ function doLogin(disableFunction: (newState: boolean) => void) {
     "height=700,width=500,location=no,menubar=no,resizable=no,status=no,titlebar=no,left=300,top=300"
   )
 
+  const interval = setInterval(() => {
+    if (windowRef?.closed) {
+      clearInterval(interval);
+      disableFunction(false);
+    }
+  }, 500)
+
   window.onmessage = (code: MessageEvent) => {
     if (code.data.hello) {
       // React DevTools has a habit of sending messages, ignore them.
@@ -62,6 +69,7 @@ function doLogin(disableFunction: (newState: boolean) => void) {
       console.log("Code received:", code.data);
 
       disableFunction(false);
+      clearInterval(interval);
 
       window.onmessage = null;
     }


### PR DESCRIPTION
Once a user starts the authorization flow the OAuth2 button disables, if the code is received the button comes back however if the user manually closes the auth window then the button will stay disabled. This PR fixes that by checking every 500ms (JavaScript does not provide an event listener for this it seems due to cross origin security) whether the child window has been closed. In future these two flows will become a bit different, one will pop a notification up saying auth was cancelled and another will contact the auth server with the received access token so that a [PASETO](https://paseto.io/) token can be issued.