### PR TITLE
Prefix Sentry release

### DIFF
--- a/.github/workflows/create_sentry_release.yml
+++ b/.github/workflows/create_sentry_release.yml
@@ -32,3 +32,4 @@ jobs:
         with:
           environment: production
           sourcemaps: ./build/static/js/
+          version_prefix: forms-frontend@


### PR DESCRIPTION
Prefix the Sentry release created by GitHub Actions with forms-frontend@ to match that which the client is reporting.﻿
