### PR TITLE
Remove Sentry tracing integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
     "@sentry/react": "^5.25.0",
-    "@sentry/tracing": "^5.25.0",
     "@svgr/webpack": "4.3.3",
     "@swc/core": "^1.2.36",
     "@swc/jest": "^0.1.2",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,16 +4,12 @@ import App from './App';
 import * as serviceWorker from './serviceWorker';
 
 import * as Sentry from "@sentry/react";
-import { Integrations } from "@sentry/tracing";
 
 import colors from "./colors";
 
 if (process.env.NODE_ENV === "production") {
   Sentry.init({
     dsn: process.env.REACT_APP_SENTRY_DSN,
-    integrations: [
-      new Integrations.BrowserTracing(),
-    ],
     tracesSampleRate: 0.25,
     release: `forms-frontend@${process.env.REACT_APP_SHA}`
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1541,17 +1541,6 @@
     hoist-non-react-statics "^3.3.2"
     tslib "^1.9.3"
 
-"@sentry/tracing@^5.25.0":
-  version "5.25.0"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-5.25.0.tgz#1cfbcf085a7a3b679f417058d09590298ddaa255"
-  integrity sha512-KcyHEGFpqSDubHrdWT/vF2hKkjw/ts6NpJ6tPDjBXUNz98BHdAyMKtLOFTCeJFply7/s5fyiAYu44M+M6IG3Bw==
-  dependencies:
-    "@sentry/hub" "5.25.0"
-    "@sentry/minimal" "5.25.0"
-    "@sentry/types" "5.25.0"
-    "@sentry/utils" "5.25.0"
-    tslib "^1.9.3"
-
 "@sentry/types@5.25.0":
   version "5.25.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.25.0.tgz#3bcf95e118d655d3f4e8bfa5f0be2e1fe4ea5307"


### PR DESCRIPTION
Removes the @sentry/tracing package and the integration.

Our Sentry plan does not support this and it's not a very useful feature for applications of this size anyway.
