### PR TITLE
Fix Environment Modifying Scripts on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@typescript-eslint/parser": "4.10.0",
     "axios": "0.21.0",
     "copy-webpack-plugin": "7.0.0",
+    "cross-env": "7.0.3",
     "eslint": "7.15.0",
     "eslint-config-react-app": "6.0.0",
     "eslint-loader": "4.0.2",
@@ -56,9 +57,9 @@
     "workbox-webpack-plugin": "6.0.2"
   },
   "scripts": {
-    "start": "NODE_ENV=development webpack serve",
-    "build": "REACT_APP_SHA=$COMMIT_REF REACT_APP_BRANCH=$BRANCH webpack",
-    "test": "jest"
+    "start": "cross-env NODE_ENV=development webpack serve",
+    "build": "cross-env REACT_APP_SHA=$COMMIT_REF REACT_APP_BRANCH=$BRANCH webpack",
+    "test": "cross-env jest"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4344,6 +4344,13 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
+cross-env@7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -4355,7 +4362,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
This PR solves [this notion ticket.](https://www.notion.so/pythondiscord/Fix-startup-environment-error-on-Windows-038862783de64ef1b595d725e9485aee)

Running the yarn startup scripts on windows would error out due to the way the environment variables are set. This PR adds [cross-env](https://www.npmjs.com/package/cross-env) to handle running the project on different platforms.

Future scripts have to be prefixed with `cross-env` to be as cross-compatible as possible.