### PR TITLE
Switch out the HashLoader

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import {
   Switch
 } from "react-router-dom";
 
-import { HashLoader } from "react-spinners";
+import { RingLoader } from "react-spinners";
 
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
@@ -31,7 +31,7 @@ function PageLoading() {
     justify-content: center;
     margin-top: 50px;
   `}>
-    <HashLoader color="white" size={100}/>
+    <RingLoader color="white" size={100}/>
   </div>
 }
 

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/react";
 
-import { HashLoader } from "react-spinners";
+import { RingLoader } from "react-spinners";
 
 import HeaderBar from "../components/HeaderBar";
 
@@ -9,7 +9,7 @@ function Loading() {
     return <div>
         <HeaderBar title={"Loading..."}/>
         <div css={{display: "flex", justifyContent: "center"}}>
-            <HashLoader color="white"/>
+            <RingLoader color="white"/>
         </div>
     </div>
 }


### PR DESCRIPTION
HashLoader is TOO SLACK-Y.

We need a better loader.

Introducing: Ring Loader, find it on this page: https://www.davidhu.io/react-spinners/