### PR TITLE
Use custom status embed to signal workflow status to Discord

### DIFF
--- a/.github/workflows/status-embed.yml
+++ b/.github/workflows/status-embed.yml
@@ -1,0 +1,56 @@
+name: Status Embed
+
+on:
+  workflow_run:
+    workflows:
+      - Test & Lint
+    types:
+      - completed
+
+jobs:
+  status_embed:
+    if: github.event.workflow_run.conclusion != 'skipped'
+    name:  Send a Status Embed to Discord
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get Pull Request Information
+        id: pr_info
+        if: github.event.workflow_run.event == 'pull_request'
+        run: |
+          curl -s -H "Authorization: token $GITHUB_TOKEN" ${{ github.event.workflow_run.artifacts_url }} > artifacts.json
+          DOWNLOAD_URL=$(cat artifacts.json | jq -r '.artifacts[] | select(.name == "pull-request-payload") | .archive_download_url')
+          [ -z "$DOWNLOAD_URL" ] && exit 1
+          wget --quiet --header="Authorization: token $GITHUB_TOKEN" -O pull_request_payload.zip $DOWNLOAD_URL || exit 2
+          unzip -p pull_request_payload.zip > pull_request_payload.json
+          [ -s pull_request_payload.json ] || exit 3
+          echo "::set-output name=pr_author_login::$(jq -r '.user.login // empty' pull_request_payload.json)"
+          echo "::set-output name=pr_number::$(jq -r '.number // empty' pull_request_payload.json)"
+          echo "::set-output name=pr_title::$(jq -r '.title // empty' pull_request_payload.json)"
+          echo "::set-output name=pr_source::$(jq -r '.head.label // empty' pull_request_payload.json)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Send an informational status embed to Discord instead of the
+      # standard embeds that Discord sends. This embed will contain
+      # more information and we can fine tune when we actually want
+      # to send an embed.
+      - name: GitHub Actions Status Embed for Discord
+        uses: SebastiaanZ/github-status-embed-for-discord@v0.3.0
+        with:
+          # Our GitHub Actions webhook
+          webhook_id: '784184528997842985'
+          webhook_token: ${{ secrets.GHA_WEBHOOK_TOKEN }}
+
+          # Workflow information
+          workflow_name: ${{ github.event.workflow_run.name }}
+          run_id: ${{ github.event.workflow_run.id }}
+          run_number: ${{ github.event.workflow_run.run_number }}
+          status: ${{ github.event.workflow_run.conclusion }}
+          sha: ${{ github.event.workflow_run.head_sha }}
+
+          # Now we can use the information extracted in the previous step:
+          pr_author_login: ${{ steps.pr_info.outputs.pr_author_login }}
+          pr_number: ${{ steps.pr_info.outputs.pr_number }}
+          pr_title: ${{ steps.pr_info.outputs.pr_title }}
+          pr_source: ${{ steps.pr_info.outputs.pr_source }}

--- a/.github/workflows/test_and_lint.yml
+++ b/.github/workflows/test_and_lint.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: EgorDm/gha-yarn-node-cache@v1
-      
+
       - name: Install dependencies
         run: yarn install
-      
+
       - name: Install dependencies
         run: yarn build
 
@@ -26,11 +26,31 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: EgorDm/gha-yarn-node-cache@v1
-      
+
       - name: Install dependencies
         run: yarn install
 
       - name: Run tests
         run: yarn test
-      
-      
+
+      # Prepare the Pull Request Payload artifact. If this fails, we
+      # we fail silently using the `continue-on-error` option. It's
+      # nice if this succeeds, but if it fails for any reason, it
+      # does not mean that our lint-test checks failed.
+      - name: Prepare Pull Request Payload artifact
+        id: prepare-artifact
+        if: always() && github.event_name == 'pull_request'
+        continue-on-error: true
+        run: cat $GITHUB_EVENT_PATH | jq '.pull_request' > pull_request_payload.json
+
+      # This only makes sense if the previous step succeeded. To
+      # get the original outcome of the previous step before the
+      # `continue-on-error` conclusion is applied, we use the
+      # `.outcome` value. This step also fails silently.
+      - name: Upload a Build Artifact
+        if: always() && steps.prepare-artifact.outcome == 'success'
+        continue-on-error: true
+        uses: actions/upload-artifact@v2
+        with:
+          name: pull-request-payload
+          path: pull_request_payload.json


### PR DESCRIPTION
I've added a `workflow`-run triggered workflow to send an enhanced status embed to our Discord webhook whenever the "Test & Lint" workflow finishes. If the Test & Lint workflow was triggered for a `pull_request`, it will now upload a build artifact to communicate details about the PR to the status embed workflow.