### PR TITLE
Replace broken webpack mode config with NODE_ENV

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,98 +3,90 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const CopyPlugin = require('copy-webpack-plugin');
 const webpack = require("webpack")
 
-module.exports = (env) => {
-  return {
+module.exports = {
     entry: "./src/index.tsx",
-    mode: env,
+    mode: process.env.NODE_ENV ? process.env.NODE_ENV : "none",
     output: {
-      path: path.resolve(__dirname, "build"),
-      filename: "[name].[contenthash].bundle.js",
-      publicPath: "/",
-      devtoolModuleFilenameTemplate: "file:///" + path.resolve(__dirname, "[resource-path]?[loaders]")
+        path: path.resolve(__dirname, "build"),
+        filename: "[name].[contenthash].bundle.js",
+        publicPath: "/",
+        devtoolModuleFilenameTemplate: "file:///" + path.resolve(__dirname, "[resource-path]?[loaders]")
     },
     optimization: {
-      splitChunks: {
-        chunks: 'all',
-        maxSize: 204800,
-      }
+        splitChunks: {
+            chunks: 'all',
+            maxSize: 204800,
+        }
     },
     resolve: {
-      extensions: ['.js', '.jsx', '.ts', '.tsx']
+        extensions: ['.js', '.jsx', '.ts', '.tsx']
     },
     module: {
-      rules: [
-        {
-          test: /\.m?js$/,
-          exclude: /(node_modules|bower_components)/,
-          use: {
-            loader: "swc-loader",
-            options: {
-              jsc: {
-                parser: {
-                  syntax: "ecmascript",
-                  jsx: true,
-                  dynamicImport: true
-                },
-                transform: {
-                  react: {
-                    pragma: "React.createElement",
-                    pragmaFrag: "React.Fragment",
-                    throwIfNamespace: true,
-                    development: false,
-                    useBuiltins: false
-                  }
+        rules: [{
+            test: /\.m?js$/,
+            exclude: /(node_modules|bower_components)/,
+            use: {
+                loader: "swc-loader",
+                options: {
+                    jsc: {
+                        parser: {
+                            syntax: "ecmascript",
+                            jsx: true,
+                            dynamicImport: true
+                        },
+                        transform: {
+                            react: {
+                                pragma: "React.createElement",
+                                pragmaFrag: "React.Fragment",
+                                throwIfNamespace: true,
+                                development: false,
+                                useBuiltins: false
+                            }
+                        }
+                    }
                 }
-              }
             }
-          }
-        },
-        {
-          test: /\.tsx?$/,
-          exclude: /(node_modules|bower_components)/,
-          use: {
-            loader: "swc-loader",
-            options: {
-              jsc: {
-                parser: {
-                  syntax: "typescript",
-                  tsx: true,
-                  dynamicImport: true
+        }, {
+            test: /\.tsx?$/,
+            exclude: /(node_modules|bower_components)/,
+            use: {
+                loader: "swc-loader",
+                options: {
+                    jsc: {
+                        parser: {
+                            syntax: "typescript",
+                            tsx: true,
+                            dynamicImport: true
+                        }
+                    }
                 }
-              }
             }
-          }
-        },
-        {
-          test: /\.svg$/,
-          loader: '@svgr/webpack'
-        }
-      ]
+        }, {
+            test: /\.svg$/,
+            loader: '@svgr/webpack'
+        }]
     },
     devServer: {
-      contentBase: path.join(__dirname, 'public'),
-      compress: true,
-      port: 3000,
-      historyApiFallback: true,
+        contentBase: path.join(__dirname, 'public'),
+        compress: true,
+        port: 3000,
+        historyApiFallback: true,
     },
     plugins: [
-      new CopyPlugin({
-        patterns: [
-          { from: 'public', to: '.' },
-        ],
-      }),
-      new webpack.EnvironmentPlugin({
+    new CopyPlugin({
+        patterns: [{
+            from: 'public',
+            to: '.'
+        }, ],
+    }), new webpack.EnvironmentPlugin({
         NODE_ENV: "production",
         REACT_APP_SHA: "development",
         REACT_APP_SENTRY_DSN: "https://false@notreal.ingest.sentry.io/1234",
         REACT_APP_BRANCH: "development",
         REACT_APP_OAUTH2_CLIENT_ID: "0",
         BACKEND_URL: "https://forms-api.pythondiscord.com/"
-      }),
-      new HtmlWebpackPlugin({
+    }), new HtmlWebpackPlugin({
         inject: true,
         template: 'public/index.html'
-      })
-    ]
-  }
+    })]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const webpack = require("webpack")
 
 module.exports = {
     entry: "./src/index.tsx",
-    mode: process.env.NODE_ENV ? process.env.NODE_ENV : "none",
+    mode: process.env.NODE_ENV,
     output: {
         path: path.resolve(__dirname, "build"),
         filename: "[name].[contenthash].bundle.js",


### PR DESCRIPTION
Replaces the config in `webpack.config.js` which sets the webpack mode from using a weird env function parameter to fetching from the `NODE_ENV` environment variable, which will always be one of "development" or "production", or alternative will default to "none".
