### PR TITLE
Add required field to question interface

### DIFF
--- a/src/api/question.ts
+++ b/src/api/question.ts
@@ -13,5 +13,6 @@ export interface Question {
     id: string,
     name: string,
     type: QuestionType,
-    data: { [key: string]: any }
+    data: { [key: string]: any },
+    required: boolean
 }


### PR DESCRIPTION
Added `required` field to match with backend after python-discord/forms-backend#48.