### PR TITLE
Fixes Broken Links To Assets

### DIFF
--- a/public/branding/browserconfig.xml
+++ b/public/branding/browserconfig.xml
@@ -2,7 +2,7 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="branding/mstile-150x150.png"/>
+            <square150x150logo src="/branding/mstile-150x150.png"/>
             <TileColor>#2d89ef</TileColor>
         </tile>
     </msapplication>

--- a/public/index.html
+++ b/public/index.html
@@ -9,12 +9,12 @@
       content="Python Discord Forms is the surveying system for the Python Discord server."
     />
 
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png" />
-    <link rel="mask-icon" href="branding/safari-pinned-tab.svg" color="#5bbad5" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <link rel="mask-icon" href="/branding/safari-pinned-tab.svg" color="#5bbad5" />
     <meta name="msapplication-TileColor" content="#2d89ef" />
-    <meta name="msapplication-config" content="branding/browserconfig.xml">
+    <meta name="msapplication-config" content="/branding/browserconfig.xml">
 
-    <link rel="manifest" href="manifest.json" />
+    <link rel="manifest" href="/manifest.json" />
     <title>Python Discord Forms</title>
   </head>
   <body>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,17 +3,17 @@
   "name": "Python Discord Forms",
   "icons": [
     {
-      "src": "branding/logo192.png",
+      "src": "/branding/logo192.png",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "branding/logo256.png",
+      "src": "/branding/logo256.png",
       "type": "image/png",
       "sizes": "256x256"
     },
     {
-      "src": "branding/logo512.png",
+      "src": "/branding/logo512.png",
       "type": "image/png",
       "sizes": "512x512"
     }


### PR DESCRIPTION
Previously, links to assets in `public/` were using relative paths, which works on the home page, but on subpages, such as forms, the app would try to fetch them from an incorrect location, and 404. This PR uses fixed paths for the assets to allow proper locating.

Note: If your IDE complains about being unable to find the files, that's because the fixed path in the source code, and in the compiled output are different (see webpack config).