### PR TITLE
Change Sentry Action

### DIFF
--- a/.github/workflows/create_sentry_release.yml
+++ b/.github/workflows/create_sentry_release.yml
@@ -34,26 +34,26 @@ jobs:
 
       - name: Create Sentry release (production)
         if: github.ref == 'refs/heads/main'
-        uses: getsentry/action-release@v1.1.5
+        uses: tclindner/sentry-releases-action@v1.2.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: python-discord
           SENTRY_PROJECT: forms-frontend
         with:
           environment: production
-          sourcemaps: ./build/
-          version: ${{ steps.commit-sha.outputs.sha }}
-          version_prefix: forms-frontend@
+          sourceMapOptions: '{"include": ["build"]}'
+          tagName: ${{ steps.commit-sha.outputs.sha }}
+          releaseNamePrefix: forms-frontend@
 
       - name: Create Sentry release (deploy preview)
         if: github.ref != 'refs/heads/main'
-        uses: getsentry/action-release@v1.1.5
+        uses: tclindner/sentry-releases-action@v1.2.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: python-discord
           SENTRY_PROJECT: forms-frontend
         with:
           environment: deploy-preview
-          sourcemaps: ./build/
-          version: ${{ steps.commit-sha.outputs.sha }}
-          version_prefix: forms-frontend@
+          sourceMapOptions: '{"include": ["build"]}'
+          tagName: ${{ steps.commit-sha.outputs.sha }}
+          releaseNamePrefix: forms-frontend@


### PR DESCRIPTION
Changes the action used in sentry releases to the one used in other projects such as python-discord/bot, as the current one does not seem to be working. 

I opened an[ issue opened upstream](https://github.com/getsentry/action-release/issues/47), but haven't gotten any feedback, will just assume that's a dead end.
