### PR TITLE
Add Docker Setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Ignore Everything
+*
+
+# Include required files
+!public/
+!src/
+!.swcrc
+!package.json
+!tsconfig.json
+!webpack.config.js
+!yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:14-slim
+WORKDIR /app
+
+# Copy in lock files
+COPY package.json .
+COPY yarn.lock .
+
+# Install dependencies
+RUN yarn install
+
+# Copy program in
+COPY . .
+
+# Serve the frontend
+ENTRYPOINT ["yarn", "run"]
+CMD ["start", "--host", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-slim
+FROM node:16-slim
 WORKDIR /app
 
 # Copy in lock files

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   mongo:
     image: mongo:latest
     ports:
-      - 27017:27017
+      - "27017:27017"
     environment:
       MONGO_INITDB_ROOT_USERNAME: forms-backend
       MONGO_INITDB_ROOT_PASSWORD: forms-backend
@@ -19,8 +19,11 @@ services:
 
   backend:
     image: ghcr.io/python-discord/forms-backend
+    depends_on:
+      - mongo
+      - snekbox
     ports:
-      - 8000:8000
+      - "8000:8000"
     environment:
       - DATABASE_URL=mongodb://forms-backend:forms-backend@mongo:27017
       - SNEKBOX_URL=http://snekbox:8060/eval
@@ -39,13 +42,10 @@ services:
     depends_on:
       - backend
     volumes:
-      - ./public:/app/public:ro
-      - ./src:/app/src:ro
-      - ./.swcrc:/app/.swcrc:ro
-      - ./tsconfig.json:/app/tsconfig.json:ro
-      - ./webpack.config.js:/app/webpack.config.js:ro
+      - .:/app:ro
+      - /app/node_modules  # Ensure dependencies do not collide with a user's local install
     ports:
-      - 3000:3000
+      - "3000:3000"
     environment:
       - BACKEND_URL=http://localhost:8000/
     env_file:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,52 @@
+version: "3.6"
+
+services:
+  mongo:
+    image: mongo:latest
+    ports:
+      - 27017:27017
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: forms-backend
+      MONGO_INITDB_ROOT_PASSWORD: forms-backend
+      MONGO_INITDB_DATABASE: pydis_forms
+
+  snekbox:
+    image: ghcr.io/python-discord/snekbox:latest
+    ipc: none
+    ports:
+      - "127.0.0.1:8060:8060"
+    privileged: true
+
+  backend:
+    image: ghcr.io/python-discord/forms-backend
+    ports:
+      - 8000:8000
+    environment:
+      - DATABASE_URL=mongodb://forms-backend:forms-backend@mongo:27017
+      - SNEKBOX_URL=http://snekbox:8060/eval
+      - OAUTH2_CLIENT_ID
+      - OAUTH2_CLIENT_SECRET
+      - ALLOWED_URL
+      - DEBUG=true
+      - PRODUCTION=false
+    env_file:
+      - .env
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    depends_on:
+      - backend
+    volumes:
+      - ./public:/app/public:ro
+      - ./src:/app/src:ro
+      - ./.swcrc:/app/.swcrc:ro
+      - ./tsconfig.json:/app/tsconfig.json:ro
+      - ./webpack.config.js:/app/webpack.config.js:ro
+    ports:
+      - 3000:3000
+    environment:
+      - BACKEND_URL=http://localhost:8000/
+    env_file:
+      - .env


### PR DESCRIPTION
Adds a docker file that builds the frontend, and a docker-compose which houses the backend and the frontend.

The main thing missing from these changes is that file reloading does not work. Webpack-dev-server by default enables the [webpack watch option](https://webpack.js.org/configuration/watch/), but for whatever reason, it doesn't work in the docker build. I've stumbled upon [this](https://stackoverflow.com/a/46844475) SO post multiple times in my search, but nothing I tried worked.

Ultimately, file watching is a QoL feature. I think not having it slows down development significantly, but I simply couldn't figure it out. It can be added in the future if someone figures it out, but for now I figure a semi-working setup is better than nothing.