### PR TITLE
Add beforeunload event listener when a form is open

### DIFF
--- a/src/pages/FormPage.tsx
+++ b/src/pages/FormPage.tsx
@@ -156,6 +156,31 @@ function FormPage(): JSX.Element {
         });
     }, []);
 
+    // This will prompt the user before they try to exit the page
+    const cancelUnload = (event: BeforeUnloadEvent) => {
+        event.preventDefault();
+        // Not all browsers listen to preventDefault
+        event.returnValue = "";
+        return "";
+    };
+
+    useEffect(() => {
+        window.onbeforeunload = cancelUnload;
+
+        // The function we return is called when the page is unloaded
+        return () => {
+            window.onbeforeunload = null;
+        };
+    }, []);
+
+    useEffect(() => {
+        if (sent) {
+            window.onbeforeunload = null;
+        } else {
+            window.onbeforeunload = cancelUnload;
+        }
+    }, [sent]);
+
     if (form && sent) {
         const thanksStyle = css`font-family: "Uni Sans", "Hind", "Arial", sans-serif; margin-top: 15.5rem;`;
         const divStyle = css`width: 80%;`;


### PR DESCRIPTION
This means that the browser will prompt the user before it tries to close the page, that way someone cannot accidentally close the page mid-submission.

Currently this does not work for the home `a` element (Python Discord logo), for some reason it does not appear to trigger the `beforeunload` event that we subscribe to. Further investigation could be made into adding an `onclick` to this element that will throw a similar prompt and potentially cancel, or find a way to also trigger `beforeunload` events when clicking this element.