### PR TITLE
Remove "Return Home" button at the bottom of a form

### DIFF
--- a/src/pages/FormPage.tsx
+++ b/src/pages/FormPage.tsx
@@ -39,7 +39,6 @@ class Navigation extends React.Component<NavigationProps> {
       > div {
         display: inline-block;
         margin: 2rem auto;
-        width: 50%;
       }
 
       @media (max-width: 870px) {
@@ -108,10 +107,6 @@ class Navigation extends React.Component<NavigationProps> {
 
         return (
             <div css={[unselectable, Navigation.containerStyles]}>
-                <div className={ "return_button" + (this.props.form_state ? "" : " closed") }>
-                    <Link to="/" css={Navigation.returnStyles}>Return Home</Link>
-                </div>
-                <br css={this.separatorStyles}/>
                 { submit }
             </div>
         );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/38372706/128269457-43f58c3e-21ff-4b90-9b82-5b46f3908e00.png)

## Reasoning

The previous Return Home button was placed at the bottom of the form, a user would only see this after filling in the whole form. Why would someone return home after filling in a whole form?

### Improvements

I didn't touch the Submit button's style much. It looks visually nice like this in my opinion. Should the button be enlarged to make up for the bigger blank-space around it?