### PR TITLE
Update issue config to allow blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Notion task board
     url: https://www.notion.so/pythondiscord/2c44f303ec36425da23494f606973f14?v=39e0f16a1ffe4152b3dccb9d5bce9301


### PR DESCRIPTION
I'm beginning of the process of moving over the issues and tasks for Forms from Notion to GitHub. To do so, I need to be able to make issues.