### PR TITLE
Set Compose Backend Start Command

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
 
   backend:
     image: ghcr.io/python-discord/forms-backend
+    command: ["uvicorn", "--reload", "--host", "0.0.0.0", "--debug", "backend:app"]
     depends_on:
       - mongo
       - snekbox


### PR DESCRIPTION
Updates the command used for the backend in the compose to the development one. The production one caused issues as it did not log any useful output like this one does, it does not refresh, and it can cause authorization issues with JWT signing.