### PR TITLE
Add Selectable Styles To Code Field

### DIFF
--- a/src/components/InputTypes/Code.tsx
+++ b/src/components/InputTypes/Code.tsx
@@ -8,6 +8,8 @@ import { EditorState } from "@codemirror/state";
 import { oneDark } from "@codemirror/theme-one-dark";
 import { EditorView, ViewUpdate } from "@codemirror/view";
 
+import { selectable } from "../../commonStyles";
+
 interface CodeProps {
     handler: (newContent: string) => void,
     questionId: string,
@@ -43,5 +45,5 @@ export default function Code(props: CodeProps): JSX.Element {
         return () => view.destroy();
     }, []);
 
-    return <div id={`${props.questionId}-code`} css={styles} />;
+    return <div id={`${props.questionId}-code`} css={[styles, selectable]} />;
 }


### PR DESCRIPTION
Adds the selectable CSS styles to the code field to fix a bug on safari
that prevented users from clicking into it and writing.

Thanks to Etzeitet & NoodleReaper for discovering this.
