### PR TITLE
Migration to official Sentry release CI action

### DIFF
--- a/.github/workflows/create_sentry_release.yml
+++ b/.github/workflows/create_sentry_release.yml
@@ -35,26 +35,24 @@ jobs:
 
       - name: Create Sentry release (production)
         if: github.ref == 'refs/heads/main'
-        uses: tclindner/sentry-releases-action@v1.2.0
+        uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: python-discord
           SENTRY_PROJECT: forms-frontend
         with:
           environment: production
-          sourceMapOptions: '{"include": ["build"]}'
-          tagName: ${{ steps.commit-sha.outputs.sha }}
-          releaseNamePrefix: forms-frontend@
+          sourcemaps: './build'
+          version_prefix: forms-frontend@
 
       - name: Create Sentry release (deploy preview)
         if: github.ref != 'refs/heads/main'
-        uses: tclindner/sentry-releases-action@v1.2.0
+        uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: python-discord
           SENTRY_PROJECT: forms-frontend
         with:
           environment: deploy-preview
-          sourceMapOptions: '{"include": ["build"]}'
-          tagName: ${{ steps.commit-sha.outputs.sha }}
-          releaseNamePrefix: forms-frontend@
+          sourcemaps: './build'
+          version_prefix: forms-frontend@


### PR DESCRIPTION
https://github.com/tclindner/sentry-releases-action no longer works, this PR migrates to the [official sentry release CI action](https://github.com/getsentry/action-release).